### PR TITLE
fix: Add mortgage balance to FinancialFlow

### DIFF
--- a/src/main/groovy/com/mkdecision/dashboard/OrderServices.groovy
+++ b/src/main/groovy/com/mkdecision/dashboard/OrderServices.groovy
@@ -689,6 +689,7 @@ class OrderServices {
                 .parameter("entryTypeEnumId", "MkEntryExpense")
                 .parameter("financialFlowTypeEnumId", "MkFinFlowMortgage")
                 .parameter("partyRelationshipId", lenderRelationshipId)
+                .parameter("balance", mortgageBalance)
                 .parameter("amount", mortgagePaymentMonthly)
                 .call()
 


### PR DESCRIPTION
I realized the mortgage balance wasn't being created, so I added it to the FinancialFlow 'balance' field